### PR TITLE
catch direct association reference error and log (#65)

### DIFF
--- a/modules/core/src/de/diedavids/cuba/dataimport/binding/AttributeBindRequest.groovy
+++ b/modules/core/src/de/diedavids/cuba/dataimport/binding/AttributeBindRequest.groovy
@@ -9,6 +9,7 @@ import com.haulmont.cuba.core.global.Metadata
 import de.diedavids.cuba.dataimport.dto.DataRow
 import de.diedavids.cuba.dataimport.entity.ImportAttributeMapper
 import de.diedavids.cuba.dataimport.entity.ImportConfiguration
+import de.diedavids.cuba.dataimport.service.AssociationDirectReferenceException
 
 class AttributeBindRequest {
 
@@ -63,7 +64,22 @@ class AttributeBindRequest {
     }
 
     boolean isAssociationBindingRequest() {
-        importEntityPropertyPath?.metaProperties?.size() > 1 ?: false
+        def metaProperties = importEntityPropertyPath?.metaProperties
+        if (metaProperties) {
+            def firstMetaProperty = metaProperties[0]
+            def firstMetaPropertyIsAssociation = firstMetaProperty.type == MetaProperty.Type.ASSOCIATION
+
+            if (firstMetaPropertyIsAssociation && metaProperties.size() == 1) {
+                throw new AssociationDirectReferenceException(
+                        metaProperty: firstMetaProperty,
+                        attributeBindRequest: this
+                )
+            }
+
+            return firstMetaPropertyIsAssociation
+        }
+
+        false
     }
 
     boolean isDatatypeBindingRequest() {

--- a/modules/core/src/de/diedavids/cuba/dataimport/binding/EntityBinderImpl.groovy
+++ b/modules/core/src/de/diedavids/cuba/dataimport/binding/EntityBinderImpl.groovy
@@ -6,6 +6,7 @@ import com.haulmont.cuba.core.global.Metadata
 import de.diedavids.cuba.dataimport.dto.DataRow
 import de.diedavids.cuba.dataimport.entity.ImportAttributeMapper
 import de.diedavids.cuba.dataimport.entity.ImportConfiguration
+import de.diedavids.cuba.dataimport.service.AssociationDirectReferenceException
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
@@ -38,9 +39,14 @@ class EntityBinderImpl implements EntityBinder {
     private void bindAttribute(ImportConfiguration importConfiguration, DataRow dataRow, Entity entity, ImportAttributeMapper importAttributeMapper) {
 
         AttributeBindRequest bindRequest = createAttributeBindRequest(importConfiguration, dataRow, importAttributeMapper)
-        AttributeBinder binder = attributeBinderFactory.createAttributeBinderFromBindingRequest(bindRequest)
+        try {
+            AttributeBinder binder = attributeBinderFactory.createAttributeBinderFromBindingRequest(bindRequest)
+            binder.bindAttribute(entity, bindRequest)
 
-        binder.bindAttribute(entity, bindRequest)
+        }
+        catch (AssociationDirectReferenceException e) {
+            log.warn("Direct association references are not supported. Specify the Lookup attribute for ${e.metaProperty}. See: https://github.com/mariodavid/cuba-component-data-import#n1-entity-association", e)
+        }
 
     }
 

--- a/modules/core/src/de/diedavids/cuba/dataimport/binding/EntityBinderImpl.groovy
+++ b/modules/core/src/de/diedavids/cuba/dataimport/binding/EntityBinderImpl.groovy
@@ -45,7 +45,7 @@ class EntityBinderImpl implements EntityBinder {
 
         }
         catch (AssociationDirectReferenceException e) {
-            log.warn("Direct association references are not supported. Specify the Lookup attribute for ${e.metaProperty}. See: https://github.com/mariodavid/cuba-component-data-import#n1-entity-association", e)
+            log.warn("Direct association references are not supported. Specify the Lookup attribute for ${e.metaProperty}. See: https://github.com/mariodavid/cuba-component-data-import#n1-entity-association. Will be ignored.", e)
         }
 
     }

--- a/modules/core/src/de/diedavids/cuba/dataimport/service/AssociationDirectReferenceException.groovy
+++ b/modules/core/src/de/diedavids/cuba/dataimport/service/AssociationDirectReferenceException.groovy
@@ -1,0 +1,12 @@
+package de.diedavids.cuba.dataimport.service
+
+import com.haulmont.chile.core.model.MetaProperty
+import de.diedavids.cuba.dataimport.binding.AttributeBindRequest
+
+
+class AssociationDirectReferenceException extends RuntimeException {
+
+    MetaProperty metaProperty
+
+    AttributeBindRequest attributeBindRequest
+}

--- a/modules/core/test/de/diedavids/cuba/dataimport/binding/EntityBinderAssociationIntegrationTest.groovy
+++ b/modules/core/test/de/diedavids/cuba/dataimport/binding/EntityBinderAssociationIntegrationTest.groovy
@@ -59,6 +59,40 @@ class EntityBinderAssociationIntegrationTest extends AbstractEntityBinderIntegra
 
 
     @Test
+    void "bindAttributes cannot create an entity if the entity attribute mapper points directly to the reference attribute"() {
+
+
+        ImportData importData = createData([
+                [team: "BAL"]
+        ])
+
+
+        MlbTeam balTeam = metadata.create(MlbTeam)
+        balTeam.name = 'Baltimore Orioles'
+        balTeam.code = 'BAL'
+        balTeam.state = State.MA
+
+        dataManager.commit(balTeam)
+
+        importConfiguration = new ImportConfiguration(
+                entityClass: 'ddcdi$MlbPlayer',
+                importAttributeMappers: [
+                        new ImportAttributeMapper(entityAttribute: 'ddcdi$MlbPlayer.team', fileColumnAlias: 'team'),
+                ],
+                transactionStrategy: ImportTransactionStrategy.SINGLE_TRANSACTION
+        )
+
+
+        MlbPlayer entity = sut.bindAttributes(importConfiguration, importData.rows[0], new MlbPlayer()) as MlbPlayer
+
+
+        assertThat(entity.getTeam()).isNull()
+
+        cont.deleteRecord(balTeam)
+    }
+
+
+    @Test
     void "bindAttributes creates an Entity with a non-unique association value"() {
 
 


### PR DESCRIPTION
This PR catches the error when a direct association references occurs, logs it and ignores the import. This is only a mid-term solution. Normally this should never happen because the UI will not allow to select direct association references or alternatively it will use the id by default.