### PR TITLE
Add parsing of Long and LocalDate attributes

### DIFF
--- a/modules/core/src/de/diedavids/cuba/dataimport/binding/DatatypeFactory.groovy
+++ b/modules/core/src/de/diedavids/cuba/dataimport/binding/DatatypeFactory.groovy
@@ -35,7 +35,7 @@ class DatatypeFactory {
             return Integer.parseInt(rawValue)
         }
         catch (NumberFormatException e) {
-            log.warn("Number could not be read: '$rawValue' for field [] in [$dataRow]. Will be ignored.")
+            log.warn("Number could not be read: '$rawValue' in [$dataRow]. Will be ignored.")
         }
     }
 
@@ -44,7 +44,7 @@ class DatatypeFactory {
             return Long.parseLong(rawValue)
         }
         catch (NumberFormatException e) {
-            log.warn("Number could not be read: '$rawValue' for field [] in [$dataRow]. Will be ignored.")
+            log.warn("Number could not be read: '$rawValue' in [$dataRow]. Will be ignored.")
         }
     }
 

--- a/modules/core/src/de/diedavids/cuba/dataimport/binding/DatatypeFactory.groovy
+++ b/modules/core/src/de/diedavids/cuba/dataimport/binding/DatatypeFactory.groovy
@@ -7,6 +7,8 @@ import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Slf4j
 @Component('ddcdi_DatatypeFactory')
@@ -17,8 +19,10 @@ class DatatypeFactory {
     Object getValue(AttributeBindRequest bindRequest) {
         switch (bindRequest.javaType) {
             case Integer: return getIntegerValue(bindRequest.rawValue, bindRequest.dataRow)
+            case Long: return getLongValue(bindRequest.rawValue, bindRequest.dataRow)
             case Double: return getDoubleValue(bindRequest.rawValue, bindRequest.dataRow)
             case Date: return getDateValue(bindRequest.importConfiguration, bindRequest.rawValue)
+            case LocalDate: return getLocalDateValue(bindRequest.importConfiguration, bindRequest.rawValue)
             case Boolean: return getBooleanValue(bindRequest.importConfiguration, bindRequest.rawValue, bindRequest.dataRow)
             case BigDecimal: return getBigDecimalValue(bindRequest.rawValue, bindRequest.dataRow)
             case String: return getStringValue(bindRequest.rawValue)
@@ -31,7 +35,16 @@ class DatatypeFactory {
             return Integer.parseInt(rawValue)
         }
         catch (NumberFormatException e) {
-            log.warn("Number could not be read: '$rawValue' in [$dataRow]. Will be ignored.")
+            log.warn("Number could not be read: '$rawValue' for field [] in [$dataRow]. Will be ignored.")
+        }
+    }
+
+    private Long getLongValue(String rawValue, DataRow dataRow) {
+        try {
+            return Long.parseLong(rawValue)
+        }
+        catch (NumberFormatException e) {
+            log.warn("Number could not be read: '$rawValue' for field [] in [$dataRow]. Will be ignored.")
         }
     }
 
@@ -65,6 +78,14 @@ class DatatypeFactory {
     private Date getDateValue(ImportConfiguration importConfiguration, String rawValue) {
         SimpleDateFormat formatter = new SimpleDateFormat(importConfiguration.dateFormat)
         formatter.parse(rawValue)
+    }
+
+    @SuppressWarnings('SimpleDateFormatMissingLocale')
+    private LocalDate getLocalDateValue(ImportConfiguration importConfiguration, String rawValue) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(importConfiguration.dateFormat);
+        //convert String to LocalDate
+        LocalDate localDate = LocalDate.parse(rawValue, formatter);
+        return localDate
     }
 
     private Double getDoubleValue(String rawValue, DataRow dataRow) {

--- a/modules/core/test/de/diedavids/cuba/dataimport/binding/DatatypeFactoryIntegrationTest.groovy
+++ b/modules/core/test/de/diedavids/cuba/dataimport/binding/DatatypeFactoryIntegrationTest.groovy
@@ -12,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -68,7 +69,7 @@ class DatatypeFactoryIntegrationTest extends AbstractEntityBinderIntegrationTest
         assertThat(result).isEqualTo(expectedBindingValue)
 
     }
-    
+
     @Test
     void "getValue can parse an Double value correctly"() {
 
@@ -108,6 +109,29 @@ class DatatypeFactoryIntegrationTest extends AbstractEntityBinderIntegrationTest
         // then:
         assertThat(result).isInstanceOf(Date)
         assertThat(result).isEqualTo(expectedBindingValue)
+
+    }
+
+    @Test
+    void "getValue can parse a LocalDate value correctly"() {
+
+        // given:
+        importAttributeMapper = attributeMapperFor('birthdayLocalDate')
+        importConfiguration = importConfigurationFor('ddcdi$MlbPlayer', importAttributeMapper)
+        def dateFormat = "yyyy-MM-dd"
+        importConfiguration.dateFormat = dateFormat
+
+        // and:
+        def expectedBindingValue = '1985-07-09'
+        def bindRequest = bindRequestFor(importConfiguration, importAttributeMapper, [birthdayLocalDate: expectedBindingValue])
+
+        // when:
+        def result = sut.getValue(bindRequest)
+
+        // then:
+        assertThat(result).isInstanceOf(LocalDate)
+        def resultAsString = result.format(DateTimeFormatter.ofPattern(dateFormat));
+        assertThat(resultAsString).isEqualTo(expectedBindingValue)
 
     }
 
@@ -154,7 +178,49 @@ class DatatypeFactoryIntegrationTest extends AbstractEntityBinderIntegrationTest
 
     }
 
-    
+    @Test
+    void "getValue can parse a Long value correctly"() {
+
+        // given:
+        importAttributeMapper = attributeMapperFor('annualSalaryLong')
+        importConfiguration = importConfigurationFor('ddcdi$MlbPlayer', importAttributeMapper)
+
+        // and:
+        def expectedBindingValue = 1000L
+
+        def bindRequest = bindRequestFor(importConfiguration, importAttributeMapper, [annualSalaryLong: expectedBindingValue])
+
+        // when:
+        def result = sut.getValue(bindRequest)
+
+        // then:
+        assertThat(result).isInstanceOf(Long)
+        assertThat(result).isEqualTo(Long.valueOf(1000L))
+
+    }
+
+
+    @Test
+    void "getValue can parse a Float value correctly"() {
+
+        // given:
+        importAttributeMapper = attributeMapperFor('annualSalaryLong')
+        importConfiguration = importConfigurationFor('ddcdi$MlbPlayer', importAttributeMapper)
+
+        // and:
+        def expectedBindingValue = 1000L
+
+        def bindRequest = bindRequestFor(importConfiguration, importAttributeMapper, [annualSalaryLong: expectedBindingValue])
+
+        // when:
+        def result = sut.getValue(bindRequest)
+
+        // then:
+        assertThat(result).isInstanceOf(Long)
+        assertThat(result).isEqualTo(Long.valueOf(1000L))
+
+    }
+
     @Test
     void "getValue can parse a Enum value correctly"() {
 

--- a/modules/core/test/de/diedavids/cuba/dataimport/create-db.sql
+++ b/modules/core/test/de/diedavids/cuba/dataimport/create-db.sql
@@ -59,8 +59,10 @@ create table DDCDI_MLB_PLAYER (
     WEIGHT integer,
     AGE double precision,
     BIRTHDAY date,
+    BIRTHDAY_LOCAL_DATE date,
     LEFT_HANDED boolean,
     ANNUAL_SALARY decimal(19, 2),
+    ANNUAL_SALARY_LONG bigint,
     --
     primary key (ID)
 )^

--- a/modules/core/test/de/diedavids/cuba/dataimport/entity/example/mlb/MlbPlayer.java
+++ b/modules/core/test/de/diedavids/cuba/dataimport/entity/example/mlb/MlbPlayer.java
@@ -5,6 +5,7 @@ import com.haulmont.cuba.core.entity.StandardEntity;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 
@@ -34,17 +35,39 @@ public class MlbPlayer extends StandardEntity {
     @Column(name = "BIRTHDAY")
     protected Date birthday;
 
+    @Column(name = "BIRTHDAY_LOCAL_DATE")
+    protected LocalDate birthdayLocalDate;
+
     @Column(name = "LEFT_HANDED")
     protected Boolean leftHanded;
 
     @Column(name = "ANNUAL_SALARY")
     protected BigDecimal annualSalary;
 
+    @Column(name = "ANNUAL_SALARY_LONG")
+    protected Long annualSalaryLong;
+
     @JoinTable(name = "DDCDI_MLB_PLAYER_BASEBALL_STRENGTH_LINK",
-        joinColumns = @JoinColumn(name = "MLB_PLAYER_ID"),
-        inverseJoinColumns = @JoinColumn(name = "BASEBALL_STRENGTH_ID"))
+            joinColumns = @JoinColumn(name = "MLB_PLAYER_ID"),
+            inverseJoinColumns = @JoinColumn(name = "BASEBALL_STRENGTH_ID"))
     @ManyToMany
     protected List<BaseballStrength> strengths;
+
+    public LocalDate getBirthdayLocalDate() {
+        return birthdayLocalDate;
+    }
+
+    public void setBirthdayLocalDate(LocalDate birthdayLocalDate) {
+        this.birthdayLocalDate = birthdayLocalDate;
+    }
+
+    public Long getAnnualSalaryLong() {
+        return annualSalaryLong;
+    }
+
+    public void setAnnualSalaryLong(Long annualSalaryLong) {
+        this.annualSalaryLong = annualSalaryLong;
+    }
 
     public void setStrengths(List<BaseballStrength> strengths) {
         this.strengths = strengths;

--- a/modules/core/test/de/diedavids/cuba/dataimport/entity/example/mlb/messages.properties
+++ b/modules/core/test/de/diedavids/cuba/dataimport/entity/example/mlb/messages.properties
@@ -11,6 +11,8 @@ MlbPlayer.strengths = Strengths
 
 
 
+MlbPlayer.annualSalaryLong=Annual salary long
+MlbPlayer.birthdayLocalDate=Birthday local date
 State.AK = Alaska
 State.AL = Alabama
 State.AR = Arkansas


### PR DESCRIPTION
Hi Mario. 

This PR is about https://www.cuba-platform.com/discuss/t/data-import-addon-bug-cannot-import-data-in-property-with-type-long/10685/2

I added parsing for `Long `and `LocalDate`. 
I added 2 unit tests in `de.diedavids.cuba.dataimport.binding.DatatypeFactoryIntegrationTest`

May be `LocalDateTime` should be added too but I don't know groovy a lot so I prefered doing limited modifications. 

Regards,
Guillaume