### PR TITLE
Update MetadataSelector.groovy

### DIFF
--- a/modules/web/src/de/diedavids/cuba/dataimport/web/util/MetadataSelector.groovy
+++ b/modules/web/src/de/diedavids/cuba/dataimport/web/util/MetadataSelector.groovy
@@ -55,7 +55,7 @@ class MetadataSelector {
         Collection<CategoryAttribute> dynamicAttributesForImportConfiguration = dynamicAttributes.getAttributesForMetaClass(entityMetaClass)
 
         dynamicAttributesForImportConfiguration.collectEntries {
-            ["${it.name} (${it.code})".toString(), it.name]
+            ["${it.name} (${it.code})".toString(), "+"+it.name]
         }
     }
     Map<String, Object> getDirectAttributesLookupFieldOptions(MetaClass entityMetaClass) {


### PR DESCRIPTION
When configuring dynamic attributes on the import mapper, the code stores the dynamic attribute without the "+" sign which Cuba requires to distinguish between built-in and dynamic properties. By including the "+" in the select options (and thereby saving it as such) this problem is avoided.